### PR TITLE
fixes off-center positions of counter across browsers

### DIFF
--- a/themes/atchai/static/src/sass/modules/_post.sass
+++ b/themes/atchai/static/src/sass/modules/_post.sass
@@ -116,12 +116,14 @@
                 background: url('/img/Bullet.svg')
                 background-size: 100%
                 background-repeat: no-repeat
-                background-position: 0px 2px
+                background-position: center center
                 padding: 14px
+                width: 42px
+                height: 42px
                 margin-right: 10px
                 color: white
                 font-family: sans-serif
-                font-size: 15px
+                font-size: 14px
             
     ul
         list-style: disc url('/img/Bullet-Ul.svg')


### PR DESCRIPTION
Tested on Safari, Chrome, Firefox on Mac
Attached screenshot

<img width="1430" alt="screen shot 2016-04-30 at 9 37 18 am" src="https://cloud.githubusercontent.com/assets/1033534/14933779/81feda24-0eb7-11e6-9a87-6a29f1acdb76.png">
